### PR TITLE
safari user notifications and macos rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Donate as much or little money as you like, of course. I have some UK charities 
   * [Processes and Networks](#processes-and-networks)
   * [Files](#files)
   * [Bash Tips](#bash-tips)
-- [MacOS](#MacOS)
+- [macOS](#macOS)
   * [Reading .plist files](#Reading-.plist-files)
   * [Quarantine Events](#Quarantine-Events)
   * [Install History](Install-History)
@@ -2990,7 +2990,7 @@ history
 
 ---
 
-# MacOS
+# macOS
 
 
 <details>
@@ -3122,6 +3122,32 @@ Show user logins and outs auditreduce -c lo /var/audit/* | praudit
 ![image](https://user-images.githubusercontent.com/44196051/170065772-cea5403b-f402-4d5a-bd04-99d4b6feb80a.png)
 
 What happened between two dates: auditreduce /var/audit/* -a 20220401 -b 20220501 | praudit 
+
+## Safari Notification
+Notification from website can persist directly through the Safari web browser. These are saved to a plist and can be read/alerted from the plist itself.
+```
+plutil -p /Users/*/Library/Safari/UserNotificationPermissions.plist
+```
+
+The output will resemble with the `Permission` being a boolean value: `0 = denied` and `1 = allowed`.
+```
+{
+  "https://twitter.com" => {
+    "Date Added" => 2022-10-25 19:18:22 +0000
+    "Permission" => 1
+  }
+  "https://drive.google.com" => {
+    "Date Added" => 2022-11-03 18:58:35 +0000
+    "Permission" => 1
+  }
+  "https://infosec.exchange" => {
+    "Date Added" => 2023-02-15 19:32:33 +0000
+    "Permission" => 1
+  }
+}
+```
+
+![image](https://github.com/Purp1eW0lf/Blue-Team-Notes/assets/72467868/4c868a43-41e9-4066-9944-c9930445f61d)
 
 ## Command line history
 
@@ -3310,7 +3336,7 @@ Example of Capa output for the keylogger
 
 #### File
 
-The command `file` is likely to be installed in most unix, MacOS, and linux OS'. Deploy it next to the file you want to interrograte
+The command `file` is likely to be installed in most unix, macOS, and linux OS'. Deploy it next to the file you want to interrograte
 
 ![image](https://user-images.githubusercontent.com/44196051/203073884-6cb75b6b-2e56-4022-b84e-e881d1556214.png)
 
@@ -4132,7 +4158,7 @@ And if we look on a linux machine, we can confirm it's a PCAP alright
 
 ### Capture on 'Nix
 
-Big old assertion coming up: generally speaking, if a system is unix-based (so BSD, Linux, and MacOS) then they will likely have `tcpdump` installed and therefore are all good to capture PACKETS.
+Big old assertion coming up: generally speaking, if a system is unix-based (so BSD, Linux, and macOS) then they will likely have `tcpdump` installed and therefore are all good to capture PACKETS.
 
 You'll need to run `sudo` in front of tcpdump, or run it as root. 
 


### PR DESCRIPTION
- added Safari User Notifications location
- renamed 'MacOS' to 'macOS'